### PR TITLE
Do not process video

### DIFF
--- a/autosubsync/preprocessing.py
+++ b/autosubsync/preprocessing.py
@@ -65,6 +65,8 @@ def extract_sound(input_video_file, output_sound_file):
         '-y', # overwrite if exists
         '-loglevel', 'error',
         '-i', input_video_file, # input
+        '-vn', # no video
+        '-sn', # no subtitles
         '-ac', '1', # convert to mono
         output_sound_file
     ]


### PR DESCRIPTION
Conversion took forever, because FFMPEG decided it should convert video.
Adding -vn -sn parameters to make sure only audio is processed.